### PR TITLE
Sets desktop image for each screen rather than just the default

### DIFF
--- a/bin/redditwallpapers
+++ b/bin/redditwallpapers
@@ -97,7 +97,7 @@ def main():
         if fail:
             continue
         if platform.system() == 'Darwin':
-            osxcmd = 'osascript -e \'tell application "Finder" to set desktop picture to POSIX file "' + imagePath + '" \''
+            osxcmd = 'osascript -e \'tell application "System Events" to set picture of every desktop to "' + imagePath + '" \''
             os.system(osxcmd)
         elif platform.system() == 'Windows':
             SPI_SETDESKWALLPAPER = 20


### PR DESCRIPTION
I don't have a linux or windows machine to test either of those, so I only pushed the OSX fix.
